### PR TITLE
Make uBlock fully configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/config.json
+# configuration files
+*config.json
+
 compile_commands.json
 *.xpi
 /stackexchange_*/

--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ The downloader does **not** support Docker due to the display requirement.
 
 Exractor CLI supports the following configuration options:
 
-| Short | Long                   | Type     | Default           | Description                                                                                                                                                                |
-| ----- | ---------------------- | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-o`  | `--outputDir <path>`   | Optional | `<cwd>/downloads` | Specifies the directory to download the archives to.                                                                                                                       |
+| Short | Long                   | Type     | Default           | Description                                                                                                                                                                 |
+| ----- | ---------------------- | -------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-o`  | `--outputDir <path>`   | Optional | `<cwd>/downloads` | Specifies the directory to download the archives to.                                                                                                                        |
+| `-k`  | `--keep-consent`       | Optional | `false`           | Whether to keep OneTrust's consent dialog. If set, you are responsible for getting rid of it yourself (uBlock can handle that for you too).                                 |
 | `-s`  | `--skip-loaded <path>` | Optional | -                 | Whether to skip over archives that have already been downloaded. An archive is considered to be downloaded if the output directory has one already & the file is not empty. |
-| -     | `--dry-run`            | Optional | -                 | Whether to actually download the archives. If set, only traverses the network's sites.                                                                                     |
+| -     | `--dry-run`            | Optional | -                 | Whether to actually download the archives. If set, only traverses the network's sites.                                                                                      |
 
 #### Captchas and other misc. barriers
 

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,38 @@
     "provider": "string, any of: native,. Can be null, which disables notifications"
   },
   "ubo": {
-    "download_url": "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi"
+    "download_url": "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi",
+    "settings": {
+      "userSettings": {
+        "advancedUserEnabled": true
+      },
+      "hiddenSettings": {},
+      "selectedFilterLists": [
+        "user-filters",
+        "ublock-filters",
+        "ublock-badware",
+        "ublock-privacy",
+        "ublock-unbreak",
+        "ublock-quick-fixes",
+        "easylist",
+        "easyprivacy",
+        "urlhaus-1",
+        "plowe-0",
+        "fanboy-cookiemonster",
+        "ublock-cookies-easylist",
+        "adguard-cookies",
+        "ublock-cookies-adguard"
+      ],
+      "whitelist": ["chrome-extension-scheme", "moz-extension-scheme"],
+      "dynamicFilters": {
+        "toAdd": [],
+        "toRemove": []
+      },
+      "userFilters": {
+        "enabled": true,
+        "trusted": true,
+        "toOverwrite": []
+      }
+    }
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,10 @@
 {
-    "email": "The email you use to log into SE",
-    "password": "The password you use to log into SE",
-    "notifications": {
-        "provider": "string, any of: native,. Can be null, which disables notifications"
-    }
+  "email": "The email you use to log into SE",
+  "password": "The password you use to log into SE",
+  "notifications": {
+    "provider": "string, any of: native,. Can be null, which disables notifications"
+  },
+  "ubo": {
+    "download_url": "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi"
+  }
 }

--- a/sedd/cli.py
+++ b/sedd/cli.py
@@ -3,11 +3,10 @@ import argparse
 from os import getcwd
 from os.path import join
 
-from typing import TypedDict
 
-
-class SEDDCLIArgs(TypedDict):
+class SEDDCLIArgs(argparse.Namespace):
     skip_loaded: bool
+    keep_consent: bool
     output_dir: str
     dry_run: bool
 
@@ -16,6 +15,7 @@ parser = argparse.ArgumentParser(
     prog="sedd",
     description="Automatic (unofficial) SE data dump downloader for the anti-community data dump format",
 )
+
 parser.add_argument(
     "-s", "--skip-loaded",
     required=False,
@@ -23,12 +23,22 @@ parser.add_argument(
     action="store_true",
     dest="skip_loaded"
 )
+
+parser.add_argument(
+    "-k", "--keep-consent",
+    required=False,
+    dest="keep_consent",
+    action="store_true",
+    default=False
+)
+
 parser.add_argument(
     "-o", "--outputDir",
     required=False,
     dest="output_dir",
     default=join(getcwd(), "downloads")
 )
+
 parser.add_argument(
     "--dry-run",
     required=False,

--- a/sedd/cli.py
+++ b/sedd/cli.py
@@ -1,0 +1,42 @@
+import argparse
+
+from os import getcwd
+from os.path import join
+
+from typing import TypedDict
+
+
+class SEDDCLIArgs(TypedDict):
+    skip_loaded: bool
+    output_dir: str
+    dry_run: bool
+
+
+parser = argparse.ArgumentParser(
+    prog="sedd",
+    description="Automatic (unofficial) SE data dump downloader for the anti-community data dump format",
+)
+parser.add_argument(
+    "-s", "--skip-loaded",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="skip_loaded"
+)
+parser.add_argument(
+    "-o", "--outputDir",
+    required=False,
+    dest="output_dir",
+    default=join(getcwd(), "downloads")
+)
+parser.add_argument(
+    "--dry-run",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="dry_run"
+)
+
+
+def parse_cli_args() -> SEDDCLIArgs:
+    return parser.parse_args()

--- a/sedd/config.py
+++ b/sedd/config.py
@@ -1,0 +1,65 @@
+from typing import TypedDict, Literal
+
+from json import load
+from os import path, getcwd
+
+
+class SEDDNotificationsConfig(TypedDict):
+    provider: Literal['native'] | None
+
+
+class SEDDUboConfig(TypedDict):
+    download_url: str
+
+
+default_ubo_url = "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi"
+
+default_notifications_config: SEDDNotificationsConfig = {
+    'provider': None
+}
+
+default_ubo_config: SEDDUboConfig = {
+    "download_url": default_ubo_url
+}
+
+
+class SEDDConfig:
+    email: str
+    password: str
+    notifications: SEDDNotificationsConfig
+    ubo: SEDDUboConfig
+
+    def __init__(self, email: str, pwd: str, notifications: SEDDNotificationsConfig, ubo: SEDDUboConfig):
+        self.email = email
+        self.password = pwd
+        self.notifications = notifications
+        self.ubo = ubo
+
+    def get_notifications_provider(self) -> Literal['native'] | None:
+        notifications_config = self.notifications
+        return notifications_config['provider'] if hasattr(notifications_config, 'provider') else None
+
+    def get_ubo_download_url(self) -> str:
+        ubo_config = self.ubo
+        return ubo_config["download_url"] if hasattr(ubo_config, 'download_url') else default_ubo_url
+
+
+def load_sedd_config() -> SEDDConfig:
+    config_path = path.join(getcwd(), 'config.json')
+
+    config: SEDDConfig = None
+
+    with open(config_path, "r") as f:
+        config = load(f)
+
+        email = config["email"]
+        password = config["password"]
+
+        notifications = config['notifications'] if hasattr(
+            config, 'notifications') else default_notifications_config
+
+        ubo = config['ubo'] if hasattr(config, 'ubo') else default_ubo_config
+
+        config = SEDDConfig(email, password, notifications, ubo)
+
+    return config

--- a/sedd/config/__init__.py
+++ b/sedd/config/__init__.py
@@ -1,0 +1,3 @@
+from .config import *
+from .defaults import *
+from .typings import *

--- a/sedd/config/config.py
+++ b/sedd/config/config.py
@@ -1,26 +1,10 @@
-from typing import TypedDict, Literal
+from typing import Literal
 
 from json import load
 from os import path, getcwd
 
-
-class SEDDNotificationsConfig(TypedDict):
-    provider: Literal['native'] | None
-
-
-class SEDDUboConfig(TypedDict):
-    download_url: str
-
-
-default_ubo_url = "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi"
-
-default_notifications_config: SEDDNotificationsConfig = {
-    'provider': None
-}
-
-default_ubo_config: SEDDUboConfig = {
-    "download_url": default_ubo_url
-}
+from .defaults import default_ubo_url, default_ubo_settings, default_notifications_config, default_ubo_config
+from .typings import SEDDNotificationsConfig, SEDDUboConfig, SEDDUboSettings
 
 
 class SEDDConfig:
@@ -37,11 +21,15 @@ class SEDDConfig:
 
     def get_notifications_provider(self) -> Literal['native'] | None:
         notifications_config = self.notifications
-        return notifications_config['provider'] if hasattr(notifications_config, 'provider') else None
+        return notifications_config['provider'] if 'provider' in notifications_config else None
 
     def get_ubo_download_url(self) -> str:
         ubo_config = self.ubo
-        return ubo_config["download_url"] if hasattr(ubo_config, 'download_url') else default_ubo_url
+        return ubo_config['download_url'] if 'download_url' in ubo_config else default_ubo_url
+
+    def get_ubo_settings(self) -> SEDDUboSettings:
+        ubo_config = self.ubo
+        return ubo_config['settings'] if 'settings' in ubo_config else default_ubo_settings
 
 
 def load_sedd_config() -> SEDDConfig:
@@ -55,10 +43,9 @@ def load_sedd_config() -> SEDDConfig:
         email = config["email"]
         password = config["password"]
 
-        notifications = config['notifications'] if hasattr(
-            config, 'notifications') else default_notifications_config
+        notifications = config['notifications'] if 'notifications' in config else default_notifications_config
 
-        ubo = config['ubo'] if hasattr(config, 'ubo') else default_ubo_config
+        ubo = config['ubo'] if 'ubo' in config else default_ubo_config
 
         config = SEDDConfig(email, password, notifications, ubo)
 

--- a/sedd/config/defaults.py
+++ b/sedd/config/defaults.py
@@ -1,0 +1,44 @@
+from .typings import SEDDNotificationsConfig, SEDDUboSettings, SEDDUboConfig
+
+default_ubo_url = "https://github.com/gorhill/uBlock/releases/download/1.59.0/uBlock0_1.59.0.firefox.signed.xpi"
+
+default_notifications_config: SEDDNotificationsConfig = {
+    'provider': None
+}
+
+default_ubo_settings: SEDDUboSettings = {
+    'userSettings': {
+        'advancedUserEnabled': True,
+    },
+    "hiddenSettings": {},
+    "selectedFilterLists": [
+        "user-filters",
+        "ublock-filters",
+        "ublock-badware",
+        "ublock-privacy",
+        "ublock-unbreak",
+        "ublock-quick-fixes",
+        "easylist",
+        "easyprivacy",
+        "urlhaus-1",
+        "plowe-0"
+    ],
+    "whitelist": [
+        "chrome-extension-scheme",
+        "moz-extension-scheme"
+    ],
+    "dynamicFilters": {
+        "toAdd": [],
+        "toRemove": []
+    },
+    "userFilters": {
+        "enabled": False,
+        "trusted": False,
+        "toOverwrite": []
+    }
+}
+
+default_ubo_config: SEDDUboConfig = {
+    'download_url': default_ubo_url,
+    'settings': default_ubo_settings
+}

--- a/sedd/config/typings.py
+++ b/sedd/config/typings.py
@@ -1,0 +1,25 @@
+from typing import TypedDict, Literal
+
+
+class SEDDNotificationsConfig(TypedDict):
+    provider: Literal['native'] | None
+
+
+class SEDDUboUserFiltersSettings(TypedDict):
+    enabled: bool
+    trusted: bool
+    toOverwrite: list[str]
+
+
+class SEDDUboSettings(TypedDict):
+    userSettings: dict[str, str | bool | int]
+    hiddenSettings: dict[str, str | bool | int]
+    selectedFilterLists: list[str]
+    whitelist: list[str]
+    dynamicFilters: dict[Literal['toAdd'] | Literal['toRemove'], list[str]]
+    userFilters: SEDDUboUserFiltersSettings
+
+
+class SEDDUboConfig(TypedDict):
+    download_url: str
+    settings: SEDDUboSettings | None

--- a/sedd/driver.py
+++ b/sedd/driver.py
@@ -25,9 +25,7 @@ def init_firefox_driver(config: SEDDConfig, output_dir: str):
     options.set_preference(
         "browser.helperApps.neverAsk.saveToDisk", "application/x-gzip")
 
-    browser = webdriver.Firefox(
-        options=options
-    )
+    browser = webdriver.Firefox(options=options)
 
     ubo_download_url = config.get_ubo_download_url()
 

--- a/sedd/driver.py
+++ b/sedd/driver.py
@@ -45,6 +45,6 @@ def init_firefox_driver(config: SEDDConfig, output_dir: str):
 
     ubo_id = browser.install_addon("ubo.xpi", temporary=True)
 
-    ubo_status = init_ubo_settings(browser, config, ubo_internal_uuid)
+    init_ubo_settings(browser, config, ubo_internal_uuid)
 
-    return browser, ubo_id, ubo_status
+    return browser, ubo_id

--- a/sedd/driver.py
+++ b/sedd/driver.py
@@ -1,0 +1,40 @@
+from os import path, makedirs
+from urllib import request
+
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+
+from .config import SEDDConfig
+
+
+def init_output_dir(output_dir: str):
+    if not path.exists(output_dir):
+        makedirs(output_dir)
+
+    print(output_dir)
+
+    return output_dir
+
+
+def init_firefox_driver(config: SEDDConfig, output_dir: str):
+    options = Options()
+    options.enable_downloads = True
+    options.set_preference("browser.download.folderList", 2)
+    options.set_preference("browser.download.manager.showWhenStarting", False)
+    options.set_preference("browser.download.dir", output_dir)
+    options.set_preference(
+        "browser.helperApps.neverAsk.saveToDisk", "application/x-gzip")
+
+    browser = webdriver.Firefox(
+        options=options
+    )
+
+    ubo_download_url = config.get_ubo_download_url()
+
+    if not path.exists("ubo.xpi"):
+        print(f"Downloading uBO from: {ubo_download_url}")
+        request.urlretrieve(ubo_download_url, "ubo.xpi")
+
+    ubo_id = browser.install_addon("ubo.xpi", temporary=True)
+
+    return browser, ubo_id

--- a/sedd/main.py
+++ b/sedd/main.py
@@ -240,9 +240,6 @@ try:
                 etags
             )
 
-    while True is True:
-        sleep(1)
-
     if observer:
         pending = state.size()
 

--- a/sedd/main.py
+++ b/sedd/main.py
@@ -7,13 +7,11 @@ from typing import Dict
 from time import sleep
 
 import re
-import os
 import sys
 from traceback import print_exception
 
-import argparse
 
-
+from .cli import parse_cli_args
 from .config import load_sedd_config
 from .data import sites
 from .meta import notifications
@@ -22,33 +20,7 @@ from . import utils
 
 from .driver import init_output_dir, init_firefox_driver
 
-parser = argparse.ArgumentParser(
-    prog="sedd",
-    description="Automatic (unofficial) SE data dump downloader for the anti-community data dump format",
-)
-parser.add_argument(
-    "-s", "--skip-loaded",
-    required=False,
-    default=False,
-    action="store_true",
-    dest="skip_loaded"
-)
-parser.add_argument(
-    "-o", "--outputDir",
-    required=False,
-    dest="output_dir",
-    default=os.path.join(os.getcwd(), "downloads")
-)
-parser.add_argument(
-    "--dry-run",
-    required=False,
-    default=False,
-    action="store_true",
-    dest="dry_run"
-)
-
-args = parser.parse_args()
-
+args = parse_cli_args()
 
 sedd_config = load_sedd_config()
 

--- a/sedd/main.py
+++ b/sedd/main.py
@@ -1,13 +1,10 @@
-from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.webdriver import WebDriver
-from selenium.webdriver.firefox.options import Options
 from selenium.common.exceptions import NoSuchElementException
 from typing import Dict
 
 
 from time import sleep
-import urllib.request
 
 import re
 import os
@@ -22,6 +19,8 @@ from .data import sites
 from .meta import notifications
 from .watcher.observer import register_pending_downloads_observer
 from . import utils
+
+from .driver import init_output_dir, init_firefox_driver
 
 parser = argparse.ArgumentParser(
     prog="sedd",
@@ -51,39 +50,11 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-def get_download_dir():
-    download_dir = args.output_dir
-
-    if not os.path.exists(download_dir):
-        os.makedirs(download_dir)
-
-    print(download_dir)
-
-    return download_dir
-
-
-options = Options()
-options.enable_downloads = True
-options.set_preference("browser.download.folderList", 2)
-options.set_preference("browser.download.manager.showWhenStarting", False)
-options.set_preference("browser.download.dir", get_download_dir())
-options.set_preference(
-    "browser.helperApps.neverAsk.saveToDisk", "application/x-gzip")
-
-browser = webdriver.Firefox(
-    options=options
-)
-
 sedd_config = load_sedd_config()
 
-ubo_download_url = sedd_config.get_ubo_download_url()
+output_dir = init_output_dir(args.output_dir)
 
-if not os.path.exists("ubo.xpi"):
-    print(f"Downloading uBO from: {ubo_download_url}")
-    urllib.request.urlretrieve(ubo_download_url, "ubo.xpi")
-
-
-ubo_id = browser.install_addon("ubo.xpi", temporary=True)
+browser, ubo_id = init_firefox_driver(sedd_config, output_dir)
 
 
 def kill_cookie_shit(browser: WebDriver):

--- a/sedd/main.py
+++ b/sedd/main.py
@@ -162,8 +162,6 @@ try:
     state, observer = register_pending_downloads_observer(args.output_dir)
 
     for site in sites.sites:
-        print(f"Extracting from {site}...")
-
         if site not in ["https://meta.stackexchange.com", "https://stackapps.com"]:
             # https://regex101.com/r/kG6nTN/1
             meta_url = re.sub(
@@ -175,6 +173,8 @@ try:
         if args.skip_loaded and main_loaded and meta_loaded:
             pass
         else:
+            print(f"Extracting from {site}...")
+
             login_or_create(browser, site)
             download_data_dump(
                 browser,

--- a/sedd/main.py
+++ b/sedd/main.py
@@ -90,7 +90,11 @@ def download_data_dump(browser: WebDriver, site: str, meta_url: str, etags: Dict
     print(f"Downloading data dump from {site}")
 
     def _exec_download(browser: WebDriver):
-        kill_cookie_shit(browser)
+        if args.keep_consent:
+            print('Consent dialog will not be auto-removed')
+        else:
+            kill_cookie_shit(browser)
+
         try:
             checkbox = browser.find_element(By.ID, "datadump-agree-checkbox")
             btn = browser.find_element(By.ID, "datadump-download-button")

--- a/sedd/meta/notifications.py
+++ b/sedd/meta/notifications.py
@@ -1,24 +1,29 @@
 from desktop_notifier import DesktopNotifier
 import asyncio
 
+from ..config import SEDDConfig
+
+
 def native(message: str, _):
     asyncio.run(
         DesktopNotifier().send(
-            title = "The data dump downloader needs attention",
-            message = f"{message}"
+            title="The data dump downloader needs attention",
+            message=f"{message}"
         )
     )
+
 
 notification_providers = {
     "native": native
 }
-def notify(message: str, config):
 
-    provider = config["notifications"]["provider"]
+
+def notify(message: str, config: SEDDConfig):
+
+    provider = config.get_notifications_provider()
+
     if provider is None:
         print(message)
         return
 
     notification_providers[provider](message, config["notifications"])
-
-

--- a/sedd/ubo/__init__.py
+++ b/sedd/ubo/__init__.py
@@ -1,0 +1,2 @@
+from .ubo import *
+from .utils import *

--- a/sedd/ubo/ubo.py
+++ b/sedd/ubo/ubo.py
@@ -1,0 +1,31 @@
+from selenium.webdriver import Firefox
+from sys import exc_info
+from time import sleep
+
+from ..config import SEDDConfig
+from .utils import ubo_set_user_settings, \
+    ubo_set_advanced_settings, ubo_set_selected_filters, \
+    ubo_set_whitelist, ubo_set_dynamic_rules, ubo_set_user_filters
+
+
+def init_ubo_settings(browser: Firefox, config: SEDDConfig, ubo_id: str) -> bool:
+    try:
+        browser.get(
+            f'moz-extension://{ubo_id}/dashboard.html#settings.html'
+        )
+
+        settings = config.get_ubo_settings()
+
+        ubo_set_user_settings(browser, settings)
+        ubo_set_advanced_settings(browser, settings)
+
+        # idk why, but applyFilterListSelection only works after a delay
+        sleep(1)
+
+        ubo_set_selected_filters(browser, settings)
+        ubo_set_whitelist(browser, settings)
+        ubo_set_dynamic_rules(browser, settings)
+        ubo_set_user_filters(browser, settings)
+    except:
+        print('Failed to set uBLock config, using defaults')
+        print(exc_info())

--- a/sedd/ubo/ubo.py
+++ b/sedd/ubo/ubo.py
@@ -5,7 +5,8 @@ from time import sleep
 from ..config import SEDDConfig
 from .utils import ubo_set_user_settings, \
     ubo_set_advanced_settings, ubo_set_selected_filters, \
-    ubo_set_whitelist, ubo_set_dynamic_rules, ubo_set_user_filters
+    ubo_set_whitelist, ubo_set_dynamic_rules, ubo_set_user_filters, \
+    ubo_reload_all_filters
 
 
 def init_ubo_settings(browser: Firefox, config: SEDDConfig, ubo_id: str) -> bool:
@@ -26,6 +27,8 @@ def init_ubo_settings(browser: Firefox, config: SEDDConfig, ubo_id: str) -> bool
         ubo_set_whitelist(browser, settings)
         ubo_set_dynamic_rules(browser, settings)
         ubo_set_user_filters(browser, settings)
+
+        ubo_reload_all_filters(browser)
     except:
         print('Failed to set uBLock config, using defaults')
         print(exc_info())

--- a/sedd/ubo/utils.py
+++ b/sedd/ubo/utils.py
@@ -1,0 +1,84 @@
+from selenium.webdriver import Firefox
+from ..config.typings import SEDDUboSettings
+
+
+def ubo_set_user_settings(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'userSettings' message to set uBO's user settings
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/settings.js#L215
+    for key, val in settings['userSettings'].items():
+        browser.execute_script("""
+            const name = arguments[0];
+            const value = arguments[1];
+
+            globalThis.vAPI.messaging.send('dashboard', {
+                what: 'userSettings', name, value,
+            });
+        """, key, val)
+
+
+def ubo_set_advanced_settings(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'writeHiddenSettings' message to set uBO's advanced settings
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/advanced-settings.js#L177
+    browser.execute_script("""
+        const settings = arguments[0];
+
+        const content = Object.entries(settings)
+                           .map(([k,v]) => `${k} ${v}`)
+                           .join('\\n');
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'writeHiddenSettings', content,
+        });
+    """, settings['hiddenSettings'])
+
+
+def ubo_set_selected_filters(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'applyFilterListSelection' message to set uBO's selected filter lists
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/storage.js#L486
+    browser.execute_script("""
+        const toSelect = arguments[0];
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'applyFilterListSelection', toSelect,
+        })
+    """, settings['selectedFilterLists'])
+
+
+def ubo_set_whitelist(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'setWhitelist' message to set uBO's trusted sites list
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/messaging.js#L225
+    browser.execute_script("""
+        const list = arguments[0];
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'setWhitelist', whitelist: list.join('\\n')
+        })
+    """, settings["whitelist"])
+
+
+def ubo_set_dynamic_rules(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'modifyRuleset' message to set uBO's dynamic rules
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/dyna-rules.js#L279
+    browser.execute_script("""
+        const { toAdd = [], toRemove = [] } = arguments[0]
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'modifyRuleset', permanent: true,
+            toAdd: toAdd.join('\\n'),
+            toRemove: toRemove.join('\\n'),
+        })
+
+    """, settings["dynamicFilters"])
+
+
+def ubo_set_user_filters(browser: Firefox, settings: SEDDUboSettings) -> None:
+    # using vAPI 'writeUserFilters' message to set uBO's user filters
+    # see: https://github.com/gorhill/uBlock/blob/master/src/js/storage.js#L582
+    browser.execute_script("""
+        const { trusted, enabled, toOverwrite = [] } = arguments[0]
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'writeUserFilters', trusted, enabled,
+            content: toOverwrite.join('\\n')
+        })
+    """, settings['userFilters'])

--- a/sedd/ubo/utils.py
+++ b/sedd/ubo/utils.py
@@ -82,3 +82,13 @@ def ubo_set_user_filters(browser: Firefox, settings: SEDDUboSettings) -> None:
             content: toOverwrite.join('\\n')
         })
     """, settings['userFilters'])
+
+
+def ubo_reload_all_filters(browser: Firefox) -> None:
+    browser.execute_async_script("""
+        const done = arguments[0]
+
+        globalThis.vAPI.messaging.send('dashboard', {
+            what: 'reloadAllFilters',
+        }).then(done)
+    """)


### PR DESCRIPTION
This PR adds, among other things, ability to fully configure uBlock to use when downloading the dumps.

As a quick summary, the changes are as follows:

- new CLI option `--keep-consent`. If set, disables explicit killing of consent dialog, either delegating it to uBlock or user action. I've set the default to `false` for backwards-compatibility, but if you think it's unnecessary, happy to switch;
- fully typed CLI options and downloader configuration;
- capability to provide explicit config for uBlock via the `ubo` field in config.json (documented in config.example.json). For the most part, it mirrors the structure of import files, except for the `userFilters` field, which is usually provided pre-serialized as a string. I opted not to do that for clarity, but also not married to the solution and can change it to be 100% compatible;
- organized most the downloader into hopefully sensible modules;